### PR TITLE
Fix permuting single-input or single-output recipes to go through all of the permutations.

### DIFF
--- a/src/control.lua
+++ b/src/control.lua
@@ -307,10 +307,10 @@ local function buildRegistry()
     for name, group in pairs(groups) do
         local limits = group.limits
         group.limits = nil
-        if limits.maxI == 0 and limits.maxR == 1 then
-            limits.maxR = 2
-        elseif limits.maxI == 1 and limits.maxR == 0 then
-            limits.maxI = 2
+        if limits.maxI == 0 and limits.maxR > 0 then
+            limits.maxR = limits.maxR + 1
+        elseif limits.maxI > 0 and limits.maxR == 0 then
+            limits.maxI = limits.maxI + 1
         end
 
         local recipeUnlocks = {}


### PR DESCRIPTION
Because the default recipe is logically the "largest" recipe in I and R, buildRegistry doesn't see it for computing maxI and maxR; if both inputs and outputs have permutations then buildRegistry correctly computes maxI and maxR anyways, since it sees maxI from every R permutation and so on.

There was a special case hack for input/output-size 2 recipes, we just needed to extend it to all recipes of this type.

This is visible with Bobs or Angels petrochem, among other mods, which has plenty of recipes like this. (I ran into it via seablock, personally)